### PR TITLE
fix: update Invest with Bank Account copy

### DIFF
--- a/InvestWithBankAccount.md
+++ b/InvestWithBankAccount.md
@@ -11,8 +11,8 @@ Dollar Cost Averaging is an investment technique that involves buying a fixed do
 
 There are two ways to top up your portfolio:
 
-1. You can invest in your assets from USDC, which is a $USD denominated Stable Coin if you have it in your Bamboo account. You can learn more about USDC Stable Coin here on our [Blog](https://www.getbamboo.io/blog/Understanding-USDC/).
-2. Invest via your bank account with the direct debit. When you top up this way, a direct debit is issued to your funding account. If you have sufficient funds, we will immediately schedule an asset purchase for you. After 1-3 bank days, you should see a direct debit from "Bamboo 61" on your funding account statement.
+1. You can invest in assets using USDC, which is a $USD denominated Stable Coin, if you have it in your Bamboo account. You can learn more about USDC Stable Coin here on our [Blog](https://www.getbamboo.io/blog/Understanding-USDC/).
+2. Invest via your bank account with a direct debit. When you top up this way, a direct debit is issued to your funding account. If you have sufficient funds, we will immediately schedule an asset purchase for you. After 1-3 bank days, you should see a direct debit from "Bamboo 61" on your funding account statement.
 
 The minimum Top-up is:
 


### PR DESCRIPTION
## Summary

- Change "You can invest in **your** assets **from** USDC" → "You can invest in assets **using** USDC"
- Add missing comma: "Stable Coin**,** if you have it"
- Change "with **the** direct debit" → "with **a** direct debit"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked "How does it work?" into a numbered list for clearer steps.
  * Clarified top-up options: invest with USDC (link to USDC blog preserved) or via bank direct debit.
  * Made funding timing and statement details explicit (bank transfers appear as “Bamboo 61” after 1–3 business days).
  * Kept minimums: $50 AUD bank (default $500/day), $5 AUD USDC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->